### PR TITLE
Add ethernet driver patch to address bridging issue

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,6 +24,7 @@ source=("https://github.com/starfive-tech/linux/archive/refs/tags/${_tag}.tar.gz
   'linux-5-fix_CVE-2022-0847_DirtyPipe.patch'
   'linux-7-constify_struct_dh_pointer_members.patch'
   'linux-8-fix_broken_gpu-drm-i2c-tda998x.patch'
+  'linux-9-fix_promisc_ethernet_driver_armbian.patch'
   'config'
   'linux.preset'
   '90-linux.hook'
@@ -43,6 +44,7 @@ sha256sums=('f66954d2cca0db1d05faa3ca42d6c75d5b8cf77f9c7ed84c54b5e05b0a7043cd'
             '725875c1d8c7bf93cadfbceedcdfaa4062661b2deeb70a75852b87cff1d50831'
             '01cf756c307a4aeda0b8c940340b75759f00ec712b9ccc217889c6ea8f94f59e'
             'a5955ef6043e89080be902f9133f56fbeb78919fa7b45d4decb9191875217897'
+            '36d71755ec52d43065a0c7e83d4eb1a7609f03dffea58dfd03b8ce8ba959823b'
             '221bfcba5c4aa1763a9fb1e60b69a81eef9fc4941d6a57778e3bfd4da69700fc'
             '7601eb46dec607aa3e66bd756db8080302ef58b35cc35dd124e14c0bea2a8cb1'
             'bac26cf387b12e7c11e25fdafb4f3792f041f0bf42f6b3af96d5255e077ab490'
@@ -52,6 +54,7 @@ sha256sums=('f66954d2cca0db1d05faa3ca42d6c75d5b8cf77f9c7ed84c54b5e05b0a7043cd'
             'e3a433213762785a64af39f22cc6a82f9717c8eb3d27b846b20e21f290eb965c'
             'fe7ed2b042006b10e1b057391cc8f12c609259330204b668152ff88950e3deae'
             '3d65589915b56de000ae7c93f5d7fbc9cf747891a45b69559ed92e03b95f692b')
+
 
 if [ "$(uname -m)" = "riscv64" ]; then
   _target=""

--- a/linux-9-fix_promisc_ethernet_driver_armbian.patch
+++ b/linux-9-fix_promisc_ethernet_driver_armbian.patch
@@ -1,0 +1,30 @@
+#https://forum.armbian.com/topic/26518-network-bridge-fails-to-initialize-vlan-in-promisc-mode-not-supported/
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
+@@ -450,12 +450,6 @@ static int dwmac4_add_hw_vlan_rx_fltr(struct net_device *dev,
+ 	if (vid > 4095)
+ 		return -EINVAL;
+ 
+-	if (hw->promisc) {
+-		netdev_err(dev,
+-			   "Adding VLAN in promisc mode not supported\n");
+-		return -EPERM;
+-	}
+-
+ 	/* Single Rx VLAN Filter */
+ 	if (hw->num_vlan == 1) {
+ 		/* For single VLAN filter, VID 0 means VLAN promiscuous */
+@@ -505,12 +499,6 @@ static int dwmac4_del_hw_vlan_rx_fltr(struct net_device *dev,
+ {
+ 	int i, ret = 0;
+ 
+-	if (hw->promisc) {
+-		netdev_err(dev,
+-			   "Deleting VLAN in promisc mode not supported\n");
+-		return -EPERM;
+-	}
+-
+ 	/* Single Rx VLAN Filter */
+ 	if (hw->num_vlan == 1) {
+ 		if ((hw->vlan_filter[0] & GMAC_VLAN_TAG_VID) == vid) {


### PR DESCRIPTION
As described here, https://forum.armbian.com/topic/26518-network-bridge-fails-to-initialize-vlan-in-promisc-mode-not-supported/
This adds a patch to allow for bridging between the two ethernet ports on VF2. Tested working. 
![image](https://github.com/cwt-vf2/linux-cwt-starfive-vf2/assets/30728609/bc83520a-1e55-41d5-9219-997eec38c9d8)
